### PR TITLE
 update the compilation mode

### DIFF
--- a/AndroidLibSVM/androidlibsvm/CMakeLists.txt
+++ b/AndroidLibSVM/androidlibsvm/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.4.1) #指定cmake版本
+
+set(jniLibs "${CMAKE_SOURCE_DIR}/src/main/jniLibs")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fexceptions -frtti")
+
+add_library( #生成函数库的名字
+             jnilibsvm
+             SHARED  #生成动态函数看
+             src/main/jni/common.cpp
+             src/main/jni/jnilibsvm.cpp
+             src/main/jni/libsvm/svm-train.cpp
+             src/main/jni/libsvm/svm-predict.cpp
+             src/main/jni/libsvm/svm-scale.cpp
+             src/main/jni/libsvm/svm.cpp ) #依赖的cpp文件
+
+#set_target_properties(jnilibsvm PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${jniLibs}/${ANDROID_ABI})
+
+find_library( #设置path变量的名称
+              log-lib
+              #指定要查询库的名字
+              log ) #在ndk开发包中查询liblog.so函数库(默认省略lib和.so),路径赋值给log-lib
+
+target_link_libraries( #目标库,和上面生成的函数库名字一至
+                       jnilibsvm
+                       android log
+                        #连接的库,根据log-lib变量对应liblog.so函数库
+                       ${log-lib} )

--- a/AndroidLibSVM/androidlibsvm/build.gradle
+++ b/AndroidLibSVM/androidlibsvm/build.gradle
@@ -13,11 +13,23 @@ android {
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
-        ndk {
-            moduleName "jnilibsvm" // <-- This is the name of my C++ module!
-            ldLibs "log"
-            stl "stlport_shared"
-            cFlags "-DDEV_NDK=1"
+        externalNativeBuild {
+            cmake {
+                arguments '-DANDROID_PLATFORM=android-15',
+                        '-DANDROID_TOOLCHAIN=clang',
+                        '-DANDROID_STL=stlport_shared',
+                        '-DCMAKE_BUILD_TYPE=Release ..'
+                cppFlags "-std=c++11","-frtti", "-fexceptions","-O3"
+            }
+        }
+        ndk{
+            abiFilters 'armeabi-v7a','arm64-v8a'
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "CMakeLists.txt"
         }
     }
 

--- a/AndroidLibSVM/app/build.gradle
+++ b/AndroidLibSVM/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "edu.umich.eecs.androidlibsvm"
-        minSdkVersion 22
+        minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Modify the minimum version requirement of the Android SDK, update the compilation mode, and avoid running on the low version of the Android system without the dependency method bug.